### PR TITLE
feat: use oneof for classifications to support bool classifications

### DIFF
--- a/athena/models.proto
+++ b/athena/models.proto
@@ -103,9 +103,16 @@ message Classification {
   // Examples: "CatA", "CatB", "Indicative", "Distraction", etc.
   string label = 1;
 
-  // Confidence score between 0.0 and 1.0 indicating certainty
-  // Higher values indicate greater confidence in the classification
-  float weight = 2;
+  oneof score {
+    // Confidence score between 0.0 and 1.0 indicating certainty
+    // Higher values indicate greater confidence in the classification
+    float weight = 2;
+
+    // Binary classification result (true/false)
+    // Used for classifications that are strictly binary in nature, such as
+    // exact match hash detection.
+    bool binary = 3;
+  }
 }
 
 // Error information for failed classification attempts.


### PR DESCRIPTION
n.b. this change is backwards compatible, as in using the current format against a server that is using the new format, as the tag for the float classification option has not changed. This is in line with proto docs:

https://protobuf.dev/programming-guides/proto3/#backward